### PR TITLE
Add Teams SDK .NET preview reference post

### DIFF
--- a/_posts/2026-06-07-announcing-teams-sdk-dotnet-2-1-preview.md
+++ b/_posts/2026-06-07-announcing-teams-sdk-dotnet-2-1-preview.md
@@ -1,0 +1,11 @@
+---
+title: Announcing Teams SDK for .NET 2.1 Preview
+layout: post
+date: 2026-06-07
+---
+
+I published a new post on the Microsoft Teams SDK blog: [Announcing Teams SDK for .NET 2.1 Preview](https://microsoft.github.io/teams-sdk/blog/announcing-teams-sdk-dotnet-2-1-preview).
+
+The preview introduces the next step for building Teams apps and agents with .NET, including native ASP.NET Core integration, a redesigned SSO experience, and support for agentic identity in Microsoft 365.
+
+If you are building bots, agents, or Teams apps with .NET, check out the announcement for the details and links to get started.


### PR DESCRIPTION
This PR adds a new blog post referencing the announcement for the Teams SDK .NET 2.1 Preview.